### PR TITLE
feat(trade-executor): Phase 5 - Mock Strategy Engine & Entry Point

### DIFF
--- a/hughs-forge/services/trade-executor/main.py
+++ b/hughs-forge/services/trade-executor/main.py
@@ -865,7 +865,7 @@ class TradeExecutor:
             logger.warning(f"Trade {trade_details} rejected by Risk Manager.")
             return {"status": "rejected", "message": "Trade rejected by Risk Manager"}
 
-        if not self.wallet:
+        if not self.wallet and not self.paper_trading_mode:
             logger.error("❌ Cannot execute trade: Wallet private key not loaded.")
             return {"status": "error", "message": "Wallet not loaded"}
         

--- a/hughs-forge/services/trade-executor/run_pipeline.py
+++ b/hughs-forge/services/trade-executor/run_pipeline.py
@@ -1,0 +1,67 @@
+import asyncio
+import logging
+import random
+import datetime
+from main import TradeExecutor, RPC_ENDPOINT, log_telemetry
+from strategy_engine import StrategyEngine
+
+# Configure root logger for the pipeline entry point
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger(__name__)
+
+async def main_loop():
+    logger.info("Initializing Crypto Trading Pipeline (Phase 5)...")
+    
+    # Initialize Trade Executor in Paper Trading mode
+    executor = TradeExecutor(RPC_ENDPOINT, private_key=None, paper_trading_mode=True)
+    
+    # Initialize Mock Strategy Engine
+    strategy = StrategyEngine(threshold_buy=-0.015, threshold_sell=0.015)
+
+    current_mock_price = 150.0 # Starting mock price for SOL
+    logger.info(f"Pipeline running. Starting mock price: ${current_mock_price:.2f}")
+
+    while True:
+        try:
+            logger.info("--- Pipeline Heartbeat ---")
+            
+            # 1. Ingest Price Data (Mocked with random walk)
+            price_shift = random.uniform(-0.03, 0.03) # Up to 3% swing
+            current_mock_price *= (1 + price_shift)
+            logger.info(f"--> Mock Price updated: ${current_mock_price:.2f}")
+
+            # 2. Evaluate Strategy
+            signal = strategy.evaluate(current_mock_price)
+            
+            # 3. Handle Signals & Telemetry
+            if signal:
+                logger.info(f"--> Signal generated: {signal}")
+                # Log the strategy signal directly to telemetry
+                log_telemetry("STRATEGY_SIGNAL", {
+                    "price": current_mock_price,
+                    "signal": signal
+                })
+                
+                # Trigger trade execution
+                executor.execute_trade(signal)
+            else:
+                logger.info("--> No signal generated. Holding position.")
+                
+            # 4. Sleep until next cycle
+            await asyncio.sleep(5) # 5 seconds for rapid testing/simulation
+
+        except Exception as e:
+            logger.error(f"Pipeline error in main loop: {e}")
+            await asyncio.sleep(5)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main_loop())
+    except KeyboardInterrupt:
+        logger.info("Pipeline terminated by user request.")

--- a/hughs-forge/services/trade-executor/strategy_engine.py
+++ b/hughs-forge/services/trade-executor/strategy_engine.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+class StrategyEngine:
+    def __init__(self, threshold_buy: float = -0.015, threshold_sell: float = 0.015):
+        """Simple momentum/threshold mock strategy."""
+        self.threshold_buy = threshold_buy
+        self.threshold_sell = threshold_sell
+        self.last_price = None
+
+    def evaluate(self, current_price: float) -> Optional[Dict]:
+        """Evaluates price action and emits a trade signal if conditions are met."""
+        if self.last_price is None:
+            self.last_price = current_price
+            return None
+
+        price_change = (current_price - self.last_price) / self.last_price
+        
+        signal = None
+        if price_change <= self.threshold_buy:
+            signal = {"action": "BUY", "amount": 10.0, "pair": "SOL/USDC", "reason": "MOMENTUM_DROP", "price_change": price_change}
+        elif price_change >= self.threshold_sell:
+            signal = {"action": "SELL", "amount": 10.0, "pair": "SOL/USDC", "reason": "MOMENTUM_SPIKE", "price_change": price_change}
+
+        if signal:
+            logger.info(f"Strategy Engine emitted signal: {signal}")
+        
+        self.last_price = current_price
+        return signal


### PR DESCRIPTION
Implements strategy_engine.py and run_pipeline.py to wire the mock strategy with TradeExecutor. Evaluates mock price data and issues BUY/SELL signals via paper trading.