### PR TITLE
ci: switch deploy workflows to self-hosted runner

### DIFF
--- a/.github/workflows/deploy-mvp.yml
+++ b/.github/workflows/deploy-mvp.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, tailscale]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/deploy-to-trade.yml
+++ b/.github/workflows/deploy-to-trade.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, tailscale]
     name: Deploy to ola-claw-trade
 
     steps:

--- a/.github/workflows/deploy-trade-executor.yml
+++ b/.github/workflows/deploy-trade-executor.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, tailscale]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/deploy-trade-services.yml
+++ b/.github/workflows/deploy-trade-services.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy-to-trade-server:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, tailscale]
     name: Deploy to ola-claw-trade
 
     steps:


### PR DESCRIPTION
## Summary
- All 4 deploy workflows now use `[self-hosted, linux, tailscale]` runner on ola-claw-dev
- CI-only workflows (phantom-gauntlet, trade-executor-ci) stay on `ubuntu-latest`
- Self-hosted runner is registered and online on ola-claw-dev with Tailscale access to ola-claw-trade

Closes #1