### PR TITLE
feat(rpc): use Helius RPC for tx landing

### DIFF
--- a/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py
+++ b/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py
@@ -39,7 +39,13 @@ class RpcIntegrator:
             with open(wallet_path, "r") as f:
                 secret_key = json.load(f)
             self.wallet = Keypair.from_bytes(bytes(secret_key))
-            self.solana_rpc = os.getenv("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+            helius_key = os.getenv("HELIUS_API_KEY", "")
+            if helius_key:
+                self.solana_rpc = os.getenv("SOLANA_RPC_URL", f"https://mainnet.helius-rpc.com/?api-key={helius_key}")
+                self.logger.info("Using Helius RPC for better tx landing")
+            else:
+                self.solana_rpc = os.getenv("SOLANA_RPC_URL", "https://api.mainnet-beta.solana.com")
+                self.logger.warning("No HELIUS_API_KEY — using public RPC (txs may drop)")
             self.client = Client(self.solana_rpc)
         else:
             self.solana_rpc = os.getenv("SOLANA_RPC_URL", "https://api.devnet.solana.com")


### PR DESCRIPTION
## Summary
- Use Helius RPC when HELIUS_API_KEY env var is set
- Falls back to public RPC if no key available
- Fixes transaction drops (both test trades submitted but never landed on chain)

## Problem
Public RPC (`api.mainnet-beta.solana.com`) silently drops transactions — validators deprioritize them. Both micro-trade attempts returned signatures but tx was never found on chain.

## Test plan
- [ ] Add HELIUS_API_KEY to Hugh's env.conf
- [ ] Restart patryn-trader
- [ ] Run 0.001 SOL → USDC micro-trade
- [ ] Verify confirmation loop shows "confirmed" (not "dropped")

🤖 Generated with [Claude Code](https://claude.com/claude-code)