### PR TITLE
test: fix profile-based scanner tests

### DIFF
--- a/test_profiles.py
+++ b/test_profiles.py
@@ -8,21 +8,21 @@ async def test_profiles():
     
     # 1. Test "Safe" Profile
     print("\n[TEST] Profile: SAFE")
-    safe_scanner = AntiRugScanner(config["profiles"]["safe"])
+    safe_scanner = AntiRugScanner(config["profiles"]["SafeSentinel"])
     
     # Mocking a "bundled" but otherwise clean token
     async def mock_bundled(mint):
         return {"is_mintable": False, "is_freezable": False, "is_lp_burned": True, "is_bundled": True, "top_10_holders_share": 10.0}
     
-    safe_scanner._fetch_gmgn_security = mock_bundled
+    safe_scanner._fetch_gmgn_advanced = mock_bundled
     res = await safe_scanner.scan_token("BUNDLED_TOKEN")
     print(f"Safe Outcome: {'PASSED' if res['passed'] else 'REJECTED'}")
     print(f"Reasons: {res['reasons']}")
     
     # 2. Test "Aggressive" Profile
     print("\n[TEST] Profile: AGGRESSIVE")
-    aggr_scanner = AntiRugScanner(config["profiles"]["aggressive"])
-    aggr_scanner._fetch_gmgn_security = mock_bundled
+    aggr_scanner = AntiRugScanner(config["profiles"]["AggressiveLabyrinth"])
+    aggr_scanner._fetch_gmgn_advanced = mock_bundled
     res = await aggr_scanner.scan_token("BUNDLED_TOKEN")
     print(f"Aggressive Outcome: {'PASSED' if res['passed'] else 'REJECTED'}")
     print(f"Reasons: {res['reasons']}")

--- a/test_scanner.py
+++ b/test_scanner.py
@@ -2,7 +2,19 @@ import asyncio
 from src.services.security_scanner import AntiRugScanner
 
 async def test_anti_rug():
-    scanner = AntiRugScanner()
+    # Minimal profile for testing scanner functionality
+    TEST_PROFILE = {
+        "security": {
+            "use_rug_check": True,
+            "use_bundle_check": True,
+            "enforce_lp_lock": True,
+            "enforce_revoked_mint": True,
+            "enforce_revoked_freeze": True,
+            "min_fee_volume_ratio": 0.001,
+            "max_holder_concentration": 25.0
+        }
+    }
+    scanner = AntiRugScanner(TEST_PROFILE)
     
     # Test 1: "Verified" Token Pattern
     print("\n[TEST] Pattern: Verified Launch (Clean)")
@@ -12,13 +24,15 @@ async def test_anti_rug():
     # Test 2: "Rug" Pattern: High Concentration + Low Fee Ratio
     print("\n[TEST] Pattern: Rug Hazard (Bundled + High Concentration + Low Fees)")
     
-    async def mock_bad_security(mint): 
-        return {"is_mintable": False, "is_freezable": True, "is_lp_burned": False, "is_bundled": True, "top_10_holders_share": 45.0}
-    async def mock_bad_market(mint): 
-        return {"volume_24h": 5000000.0, "total_fees": 500.0} # 0.01% ratio
+    async def mock_bad_baseline(mint): 
+        # Baseline security failures: LP not burned, freeze authority present
+        return {"is_mintable": False, "is_freezable": True, "is_lp_burned": False, "rugcheck_score": 20}
+    async def mock_bad_advanced(mint): 
+        # Advanced market failures: bundled, high concentration, low fee ratio
+        return {"is_bundled": True, "top_10_holders_share": 45.0, "volume_24h": 5000000.0, "total_fees": 500.0} # fee ratio 0.0001
     
-    scanner._fetch_gmgn_security = mock_bad_security
-    scanner._fetch_gmgn_market = mock_bad_market
+    scanner._fetch_rugcheck_baseline = mock_bad_baseline
+    scanner._fetch_gmgn_advanced = mock_bad_advanced
     
     res = await scanner.scan_token("RUG_MINT_456")
     print(f"Outcome: {'PASSED' if res['passed'] else 'REJECTED'}")


### PR DESCRIPTION
Fix failing tests that were out of sync with the profile-based config changes:

- test_scanner.py: add required profile argument to AntiRugScanner constructor
- test_profiles.py: update profile keys from 'safe'/'aggressive' to 'SafeSentinel' and 'AggressiveLabyrinth'

Both tests verified passing locally.

No regressions.