### PR TITLE
fix(rpc): fix confirmation enum comparison

### DIFF
--- a/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py
+++ b/hughs-forge/services/trade-orchestrator/src/core/rpc_integration.py
@@ -177,7 +177,7 @@ class RpcIntegrator:
                     # confirmationStatus: processed -> confirmed -> finalized
                     conf = status.confirmation_status
                     self.logger.info(f"Transaction status: {conf}")
-                    if conf in ("confirmed", "finalized"):
+                    if str(conf) in ("confirmed", "finalized") or "Confirmed" in str(conf) or "Finalized" in str(conf):
                         return True
             except Exception as e:
                 self.logger.warning(f"Status check error: {e}")


### PR DESCRIPTION
## Summary
- Fix `_confirm_transaction` to handle `TransactionConfirmationStatus` enum properly
- Without this, confirmation loop always times out at 30s even when tx is confirmed

## Problem
`status.confirmation_status` returns `TransactionConfirmationStatus.Confirmed` (enum), not the string `"confirmed"`. The `in ("confirmed", "finalized")` check never matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)