### PR TITLE
fix: kill feed silent drop — add heartbeat + logging

### DIFF
--- a/combined_runner.py
+++ b/combined_runner.py
@@ -39,6 +39,8 @@ logger = logging.getLogger("CombinedRunner")
 # ============ GLOBAL FOR CALLBACK ============
 g_event_loop = None
 g_momentum_scanner = None
+_callback_count = 0
+_callback_drop_count = 0
 
 # ============ RUNNER CLASS ============
 class CombinedRunner:
@@ -141,8 +143,14 @@ class CombinedRunner:
         # Define Pump.fun token callback
         async def on_token_discovered_local(mint: str, metadata: dict):
             """Callback for Pump.fun scanner: validates momentum then enqueues to orchestrator."""
+            global _callback_count, _callback_drop_count
+            _callback_count += 1
             symbol = metadata.get('symbol', 'UNKNOWN')
-            logger.debug(f"Scanner discovered token: {symbol} ({mint})")
+
+            # Heartbeat every 50 tokens so journal shows the callback is alive
+            if _callback_count % 50 == 0:
+                logger.info(f"[HEARTBEAT] Processed {_callback_count} tokens ({_callback_drop_count} no-data drops)")
+
             try:
                 intel = await self.momentum_scanner.validate_momentum(mint)
                 if not intel.get("passed"):
@@ -150,8 +158,10 @@ class CombinedRunner:
                     reasons_list = intel.get("reasons", [])
                     metrics = intel.get("metrics", {})
 
-                    # Skip boring/fake tokens entirely (no DEX Screener data)
+                    # Skip tokens with no DEX Screener data but LOG it
                     if not metrics:
+                        _callback_drop_count += 1
+                        logger.debug(f"Token {symbol} skipped (no DEX data)")
                         return
 
                     if reasons_list:


### PR DESCRIPTION
## Summary
- Kill feed (#hands-kill-feed) went silent because `validate_momentum` returns empty metrics when DEX Screener API is down/rate-limited
- `if not metrics: return` silently dropped ALL tokens with zero logging — impossible to diagnose from journal
- Added heartbeat log every 50 tokens + no-data drop counter for observability

## Changes
- `combined_runner.py`: heartbeat every 50 tokens, track drop count, debug-level log for individual drops

## Test plan
- [ ] CI passes (phantom-gauntlet)
- [ ] Merge to main triggers deploy-mvp.yml
- [ ] After deploy: `journalctl --user -u patryn-trader -f` shows `[HEARTBEAT]` lines
- [ ] Kill feed posts rejection embeds for tokens WITH data

Closes #88

Generated with [Claude Code](https://claude.com/claude-code)