### PR TITLE
fix: retry queue aiohttp task context error

### DIFF
--- a/combined_runner.py
+++ b/combined_runner.py
@@ -384,15 +384,27 @@ class CombinedRunner:
     async def _run_retries(self, tokens):
         """Process a batch of retry tokens. Returns list of mints to remove from queue."""
         processed = []
+        tasks = []
+        mints_in_order = []
         for mint, entry in tokens:
             entry["retries"] += 1
-            try:
-                done = await self._process_retry_token(mint, entry)
-                if done:
-                    processed.append(mint)
-            except Exception as e:
-                logger.warning(f"Retry error for {entry['symbol']}: {e}")
+            mints_in_order.append(mint)
+            tasks.append(asyncio.ensure_future(self._safe_retry(mint, entry)))
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for mint, result in zip(mints_in_order, results):
+            if isinstance(result, Exception):
+                logger.warning(f"Retry task error for {mint[:8]}: {result}")
+            elif result:
+                processed.append(mint)
         return processed
+
+    async def _safe_retry(self, mint: str, entry: dict) -> bool:
+        """Wrapper that runs retry inside a proper Task context (required by aiohttp)."""
+        try:
+            return await self._process_retry_token(mint, entry)
+        except Exception as e:
+            logger.warning(f"Retry error for {entry['symbol']}: {e}")
+            return False
 
     def _check_balance(self):
         """Check SOL balance of trading wallet. Returns balance in SOL or None on error."""


### PR DESCRIPTION
## Problem
The retry loop ran DEX Screener calls with `asyncio.new_event_loop() + run_until_complete()`, which executes bare coroutines — not asyncio Tasks. aiohttp's timeout requires being inside a Task, so every retry call was crashing:

```
DEX Screener fetch failed: Timeout context manager should be used inside a task
```

Result: queue filled up but nothing was ever processed — all retries silently failed.

## Fix
- Use `asyncio.ensure_future()` + `asyncio.gather()` so each retry token runs as a proper Task
- Add `_safe_retry()` wrapper to isolate per-token exceptions from the batch

## Test plan
- [ ] CI passes
- [ ] After deploy, journal shows `Retry queue: processed=N` with N > 0
- [ ] Kill feed shows rejections or signals from aged tokens