### PR TITLE
fix: read SOLANA_RPC_URL env var (trader was hardcoded to devnet)

### DIFF
--- a/combined_runner.py
+++ b/combined_runner.py
@@ -458,7 +458,7 @@ class CombinedRunner:
 def main():
     parser = argparse.ArgumentParser(description="Combined Pump.fun Scanner + TradeOrchestrator")
     parser.add_argument('--dry-run', action='store_true', help='Run without real transactions')
-    parser.add_argument('--rpc', default='https://api.devnet.solana.com', help='Solana RPC URL')
+    parser.add_argument('--rpc', default=os.getenv('SOLANA_RPC_URL', 'https://api.devnet.solana.com'), help='Solana RPC URL')
     parser.add_argument('--health-port', type=int, default=8002, help='Health check port')
     parser.add_argument('--meteora', action='store_true', help='Enable Meteora DLMM scanner')
     args = parser.parse_args()


### PR DESCRIPTION
## Problem

`--rpc` argparse default was hardcoded to `https://api.devnet.solana.com` with no env var override. The start script passes no `--rpc` flag, so the trader has been running on **devnet the entire time** — no real trades possible.

## Fix

One-line change: argparse default now checks `SOLANA_RPC_URL` env var first.

## Required env.conf change (owner must apply on Hugh)

Add to `~/.config/systemd/user/patryn-trader.service.d/env.conf`:
```
Environment="SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=<HELIUS_API_KEY>"
```

Also remove/update the stale leash vars that override the new lower defaults from PR #194:
```
# Remove these (or update to new values):
# LEASH_MIN_VOL_5M_SOL=7     → new default is 2
# LEASH_MIN_BUYERS_1H=50     → new default is 10  
# LEASH_MIN_BUYERS_PER_5M=10 → new default is 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)