### PR TITLE
feat: broadcast queued-for-retry embed to kill feed

### DIFF
--- a/combined_runner.py
+++ b/combined_runner.py
@@ -329,7 +329,14 @@ class CombinedRunner:
                 "retries": 0,
             }
             qsize = len(self._retry_queue)
-        logger.info(f"Token {metadata.get('symbol', 'UNKNOWN')} queued for retry (queue={qsize})")
+        symbol = metadata.get("symbol", "UNKNOWN")
+        logger.info(f"Token {symbol} queued for retry (queue={qsize})")
+        if self.broadcaster:
+            self.broadcaster.broadcast_queued_for_retry({
+                "mint": mint,
+                "symbol": symbol,
+                "queue_size": qsize,
+            })
 
     def _start_retry_loop(self):
         """Background thread that re-checks queued tokens every RETRY_INTERVAL_S seconds."""

--- a/hughs-forge/services/trade-orchestrator/src/feed/discord_broadcaster.py
+++ b/hughs-forge/services/trade-orchestrator/src/feed/discord_broadcaster.py
@@ -130,6 +130,28 @@ class DiscordBroadcaster:
         embed = self._build_scanner_rejected_embed(token_data, skipped)
         self._send(embed)
 
+    def broadcast_queued_for_retry(self, token_data: Dict[str, Any]):
+        """Send an embed when a token is queued for retry (no DEX data yet)."""
+        if not self.webhook_url:
+            return
+        if not self._consume_scanner_token():
+            return
+        mint = token_data.get("mint", "")
+        symbol = token_data.get("symbol", "UNKNOWN")
+        queue_size = token_data.get("queue_size", "?")
+        desc = f"**{symbol}**\n`{mint}`"
+        embed = {
+            "title": "Queued — Waiting for DEX Data",
+            "description": desc,
+            "color": 0x5865F2,  # blurple
+            "timestamp": datetime.utcnow().isoformat(),
+            "fields": [
+                {"name": "Status", "value": "No pairs on DEX Screener yet — will retry every 30s for up to 15 min", "inline": False},
+                {"name": "Queue Size", "value": str(queue_size), "inline": True},
+            ]
+        }
+        self._send(embed)
+
     def broadcast_balance_alert(self, balance_sol: float, alert_type: str, threshold: float):
         """Send balance alert (low or high)."""
         if not self.webhook_url:


### PR DESCRIPTION
## What

When a Pump.fun token is detected but has no DEX Screener data yet, post a blurple embed to #hands-kill-feed instead of going silent. Shows:
- Token symbol + mint (copyable)
- Status message explaining it's waiting for DEX data
- Current queue size

## Why

Kill feed was completely silent on new token detection — no way to know if the sniper was alive. Now every queued token shows up immediately, giving visibility into activity even before DEX data appears.

## Rate limiting

Uses the existing scanner rate limiter (10/min) so a burst of new tokens won't spam the channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)