### PR TITLE
fix: update queued embed status text from 15 min to 24h

### DIFF
--- a/hughs-forge/services/trade-orchestrator/src/feed/discord_broadcaster.py
+++ b/hughs-forge/services/trade-orchestrator/src/feed/discord_broadcaster.py
@@ -146,7 +146,7 @@ class DiscordBroadcaster:
             "color": 0x5865F2,  # blurple
             "timestamp": datetime.utcnow().isoformat(),
             "fields": [
-                {"name": "Status", "value": "No pairs on DEX Screener yet — will retry every 30s for up to 15 min", "inline": False},
+                {"name": "Status", "value": "No pairs on DEX Screener yet — watching for up to 24h (checks back off as token ages)", "inline": False},
                 {"name": "Queue Size", "value": str(queue_size), "inline": True},
             ]
         }


### PR DESCRIPTION
Stale hardcoded text in the queued-for-retry embed. Updated to reflect the 24h adaptive retry window from PR #202.